### PR TITLE
Gh 10 namedpipe wait

### DIFF
--- a/hdfsconnector.cpp
+++ b/hdfsconnector.cpp
@@ -678,15 +678,8 @@ int Hdfs_Connector::mergeFile(const char * filename, unsigned nodeid, unsigned c
             unsigned bytesWrittenSinceLastFlush = 0;
 
             string filepartname;
-            filepartname.append(filename);
-            filepartname.append("-parts/part_");
-            stringstream ss;
-            ss << nodeid;
-            filepartname.append(ss.str());
-            filepartname.append("_");
-            ss.str("");
-            ss << clustercount;
-            filepartname.append(ss.str());
+
+            createFilePartName(&filepartname, filename, nodeid, clustercount);
 
             if (hdfsExists(fs, filepartname.c_str()) == 0)
             {
@@ -776,15 +769,8 @@ int Hdfs_Connector::writeFlatOffset(const char * filename, unsigned nodeid, unsi
     }
 
     string filepartname;
-    filepartname.append(filename);
-    filepartname.append("-parts/part_");
-    stringstream ss;
-    ss << nodeid;
-    filepartname.append(ss.str());
-    filepartname.append("_");
-    ss.str("");
-    ss << clustercount;
-    filepartname.append(ss.str());
+
+    createFilePartName(&filepartname, filename, nodeid, clustercount);
 
     hdfsFile writeFile = hdfsOpenFile(fs, filepartname.c_str(), O_CREAT | O_WRONLY, 0, 1, 0);
 
@@ -1171,14 +1157,7 @@ int main(int argc, char **argv)
     }
     else
     {
-        fprintf(stderr, "Could not connect to hdfs on %s:%d\n", hadoopHost, hadoopPort);
-        if(action == HPA_STREAMOUTPIPE)
-        {
-            fprintf(stderr, "Attempting to close named pipe: %s\n", pipepath);
-            ifstream in;
-            in.open(pipepath, ios::in | ios::binary);
-            in.close();
-        }
+        fprintf(stderr, "Could not connect to HDFS on %s:%d\n", hadoopHost, hadoopPort);
     }
     return returnCode;
 }

--- a/hdfsconnector.hpp
+++ b/hdfsconnector.hpp
@@ -32,6 +32,20 @@ using std::vector;
 #define EOL "\n"
 #define RETURN_FAILURE -1
 
+
+static inline void createFilePartName(string * filepartname, const char * filename, unsigned int nodeid, unsigned int clustercount)
+{
+    filepartname->append(filename);
+    filepartname->append("-parts/part_");
+    stringstream ss;
+    ss << nodeid;
+    filepartname->append(ss.str());
+    filepartname->append("_");
+    ss.str("");
+    ss << clustercount;
+    filepartname->append(ss.str());
+}
+
 class Hdfs_Connector
 {
 private:

--- a/hdfspipe.in
+++ b/hdfspipe.in
@@ -110,7 +110,7 @@ elif [ $1 = "-sop" ];
 then
     pipepath=/tmp/HPCCPIPE_$nodeid;
     mkfifo $pipepath 2> /tmp/HPCC-FIFO.err.$PID;
-    chmod 666 $pipepath 2> /tmp/HPCC-FIFO.err.$PID;
+    chmod 777 $pipepath 2> /tmp/HPCC-FIFO.err.$PID;
 
     echo "mkfifo $pipepath setup ..."           >> $LOG
 
@@ -118,7 +118,8 @@ then
     then
         rm -f /tmp/HPCC-FIFO.err.$PID 2> /dev/null
     else
-        echo "  WARNING (hdfsconnector mkfifo) error registered in file: /tmp/HPCC-FIFO.err.$PID " >> $LOG
+        echo "Error while setting up named pipe, registered in file: /tmp/HPCC-FIFO.err.$PID " >> $LOG
+        exit 1
     fi
     /opt/HPCCSystems/bin/hdfsconnector  "${@}" -pipepath $pipepath	2>> $LOG &
 
@@ -127,10 +128,20 @@ then
     echo h2h pid: ${h2hpid} >> $LOG
     echo "redirecting stdin to named pipe ... "    >> $LOG
 
-	cat < /dev/stdin > "$pipepath" &
-    ls -l "$HPCCTMPFILE"                        >> $LOG
+    cat < /dev/stdin > "$pipepath" &
+    ls -l "$pipepath"                               >> $LOG
+    echo "Waiting on hdfsconnector PID ${h2hpid}"   >> $LOG
     wait ${h2hpid};
     h2hstatus=$?;
+    echo "Finished waiting on hdfsconnector exit status: ${h2hstatus}" >> $LOG
+
+    if [ ${h2hstatus} -ne 0 ];
+    then
+        echo "Closing pipe due to hdfsconnector error" >> $LOG
+        exec  <&- 2>> $LOG
+        exec $pipepath <&- 2>> $LOG
+    fi
+    rm -f $pipepath 2>> $LOG
 else
     echo "Error: check your params."             >> $LOG;
     h2hstatus=1;


### PR DESCRIPTION
Code reviewed by Phil S.

Includes commits from gh8 (pull12):
https://github.com/hpcc-systems/h2h/pull/12

Closes named pipe in case hdfsconnector did not consume pipe. Prevents ECLPIPE process blocking on pipe stream reader.
