### PR TITLE
GH-22 Fix CMAKE build process

### DIFF
--- a/cmake_modules/FindLIBHDFS.cmake
+++ b/cmake_modules/FindLIBHDFS.cmake
@@ -59,16 +59,16 @@ if (NOT LIBHDFS_FOUND)
         SET (libhdfspath "/usr/lib")
       ENDIF()
     ELSEIF(WIN32)
-      SET (libhdfspaths "lib")
+      SET (libhdfspath "lib")
     ELSE()
-      SET (libhdfspaths "unknown")
+      SET (libhdfspath "unknown")
     ENDIF()
 
     # standard install doesn't include header, look in untared location
     FIND_PATH (LIBHDFS_INCLUDE_DIR NAMES hdfs.h PATHS "${TARBALLED_HADOOP_PATH}/src/c++/libhdfs" )
 
     IF (NOT ("${libhdfspaths}" STREQUAL "unknown"))
-         #FIND_LIBRARY (LIBHDFS_LIBRARIES NAMES ${libhdfs_libs} PATHS "${libhdfspaths}")
+         FIND_LIBRARY (LIBHDFS_LIBRARIES NAMES ${libhdfs_libs} PATHS "${libhdfspath}")
     ENDIF()
 
   ENDIF()


### PR DESCRIPTION
Enable FIND_LIBRARY command inadvertently commented out, and use correct
path variable name.

Change was successfully tested on Jenkins build environment:
http://10.176.141.12:8080/job/H2H-RJPBranch/1/CE-HDFS=opensuse_11_4_x86_64/

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
