### PR TITLE
gh-24 Use correct openjdk name for centOS

### DIFF
--- a/cmake_modules/dependencies/el5.cmake
+++ b/cmake_modules/dependencies/el5.cmake
@@ -1,2 +1,2 @@
 #centOS Redhat 5.x
-set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, openjdk-6-jre")
+set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1.6.0-openjdk")

--- a/cmake_modules/dependencies/el6.cmake
+++ b/cmake_modules/dependencies/el6.cmake
@@ -1,2 +1,2 @@
 #centOS Redhat 6.x
-set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, openjdk-6-jre")
+set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1.6.0-openjdk")


### PR DESCRIPTION
Use correct openjdk name for centOS: java-1.6.0-openjdk

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
