### PR TITLE
GH-27 Do not attempt to report empty CSV attributes

### DIFF
--- a/ecl/HDFSConnector.ecl
+++ b/ecl/HDFSConnector.ecl
@@ -94,7 +94,7 @@ EXPORT HDFSConnector := MODULE
             #IF ( LENGTH(%quoteseq%) > 0)
                 + ' -quote ' + '\'' + %quoteseq% + '\''
             #END
-                + '';
+                ; //Do not remove terminating semicolon
 
             ECL_RS:= PIPE( %pipecmndstr%, Layout, HadoopFileFormat);
 		#ELSE


### PR DESCRIPTION
This change should be merged into Beta1_3.6.x and master.

The H2H pipein macro erroneously attempted to report CSV format attributes
to the H2H process, even when the attributes were blank.

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
