### PR TITLE
HH-52 Add WebHDFS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,16 +14,23 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
+CMAKE_MINIMUM_REQUIRED (VERSION 2.6)
+SET ( PRODUCT_PREFIX "hpccsystems" )
 
-project (hpccsystems-hdfsconnector)
-cmake_minimum_required (VERSION 2.6)
+option(BUILD_WEBHDFS_VER "Build WebHDFS version of HDFSConnector." ON)
+
+IF( BUILD_WEBHDFS_VER )
+    SET (HDFS_CONNECTOR_TYPE "webhdfsconnector")
+ELSE()
+    SET (HDFS_CONNECTOR_TYPE "libhdfsconnector")
+ENDIF()
+
+PROJECT (${PRODUCT_PREFIX}-${HDFS_CONNECTOR_TYPE})
 
 SET ( HPCC_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 INCLUDE (${HPCC_SOURCE_DIR}/version.cmake)
 
 SET ( CMAKE_MODULE_PATH "${HPCC_SOURCE_DIR}/cmake_modules")
-#SET ( EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/bin" )
-SET ( PRODUCT_PREFIX "hpccsystems" )
 
 INCLUDE(${CMAKE_MODULE_PATH}/optionDefaults.cmake)
 INCLUDE(${CMAKE_MODULE_PATH}/commonSetup.cmake)
@@ -37,21 +44,21 @@ SET ( CPACK_SOURCE_GENERATOR TGZ )
 SET ( CPACK_RPM_PACKAGE_VERSION "${projname}")
 SET ( CPACK_RPM_PACKAGE_RELEASE "${version}${stagever}")
 
-if ( ${ARCH64BIT} EQUAL 1 )
-    set ( CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
-else( ${ARCH64BIT} EQUAL 1 )
-    set ( CPACK_RPM_PACKAGE_ARCHITECTURE "i386")
-endif ( ${ARCH64BIT} EQUAL 1 )
+IF ( ${ARCH64BIT} EQUAL 1 )
+    SET ( CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
+ELSE( ${ARCH64BIT} EQUAL 1 )
+    SET ( CPACK_RPM_PACKAGE_ARCHITECTURE "i386")
+ENDIF ( ${ARCH64BIT} EQUAL 1 )
 
 SET ( CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${CPACK_RPM_PACKAGE_ARCHITECTURE}")
 
-if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
-    set(CPACK_STRIP_FILES TRUE)
-endif()
+IF ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    SET (CPACK_STRIP_FILES TRUE)
+ENDIF()
 
 SET ( CPACK_INSTALL_CMAKE_PROJECTS "${CMAKE_CURRENT_BINARY_DIR};hdfsconnector;ALL;/")
 
-if ( CMAKE_SYSTEM MATCHES Linux )
+IF ( CMAKE_SYSTEM MATCHES Linux )
     EXECUTE_PROCESS (
                 COMMAND ${CMAKE_MODULE_PATH}/distrocheck.sh
                     OUTPUT_VARIABLE packageManagement
@@ -68,22 +75,22 @@ if ( CMAKE_SYSTEM MATCHES Linux )
                         ERROR_VARIABLE  packageRevision
                 )
 
-    message ( "-- Auto Detecting Packaging type")
-    message ( "-- distro uses ${packageManagement}, revision is ${packageRevisionArch}" )
+    MESSAGE ( "-- Auto Detecting Packaging type")
+    MESSAGE ( "-- distro uses ${packageManagement}, revision is ${packageRevisionArch}" )
 
-    if ( ${packageManagement} STREQUAL "DEB" )
-        set(CPACK_PACKAGE_FILE_NAME     "${CMAKE_PROJECT_NAME}-${version}-${stagever}${packageRevisionArch}")
-    elseif ( ${packageManagement} STREQUAL "RPM" )
-        set(CPACK_PACKAGE_FILE_NAME     "${CMAKE_PROJECT_NAME}-${version}-${stagever}.${packageRevisionArch}")
-    else()
-        set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${version}-${stagever}${CPACK_SYSTEM_NAME}")
-    endif ()
+    IF ( ${packageManagement} STREQUAL "DEB" )
+        SET(CPACK_PACKAGE_FILE_NAME     "${CMAKE_PROJECT_NAME}-${version}-${stagever}${packageRevisionArch}")
+    ELSEIF ( ${packageManagement} STREQUAL "RPM" )
+        SET(CPACK_PACKAGE_FILE_NAME     "${CMAKE_PROJECT_NAME}-${version}-${stagever}.${packageRevisionArch}")
+    ELSE()
+        SET(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${version}-${stagever}${CPACK_SYSTEM_NAME}")
+    ENDIF ()
 
-endif ( CMAKE_SYSTEM MATCHES Linux )
+ENDIF ( CMAKE_SYSTEM MATCHES Linux )
 
 MESSAGE ("-- Current release version is ${CPACK_PACKAGE_FILE_NAME}")
 
-set( CPACK_SOURCE_GENERATOR TGZ )
+SET ( CPACK_SOURCE_GENERATOR TGZ )
 
 ###
 ## CPack commands in this section require cpack 2.8.1 to function.
@@ -91,116 +98,124 @@ set( CPACK_SOURCE_GENERATOR TGZ )
 ## an RPM.
 ###
 
-if (NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.1")
-    if ( CMAKE_SYSTEM MATCHES Linux )
-        if ( ${packageManagement} STREQUAL "DEB" )
-            if ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.2")
-                message("WARNING: CMAKE 2.8.2  would not build DEB package")
-            else ()
-                set ( CPACK_GENERATOR "${packageManagement}" )
-                message("-- Will build DEB package")
+IF (NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.1")
+    IF ( CMAKE_SYSTEM MATCHES Linux )
+        IF ( ${packageManagement} STREQUAL "DEB" )
+            IF ("${CMAKE_VERSION}" VERSION_EQUAL "2.8.2")
+                MESSAGE("WARNING: CMAKE 2.8.2  would not build DEB package")
+            ELSE ()
+                SET ( CPACK_GENERATOR "${packageManagement}" )
+                MESSAGE("-- Will build DEB package")
                 ###
                 ## CPack instruction required for Debian
                 ###
-                message ("-- Packing BASH installation files")
-                set ( CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_BINARY_DIR}/postinst;${CMAKE_CURRENT_BINARY_DIR}/prerm;${CMAKE_CURRENT_BINARY_DIR}/postrm" )
-            endif ()
+                MESSAGE ("-- Packing BASH installation files")
+                SET ( CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_BINARY_DIR}/postinst;${CMAKE_CURRENT_BINARY_DIR}/prerm;${CMAKE_CURRENT_BINARY_DIR}/postrm" )
+            ENDIF ()
 
-        elseif ( ${packageManagement} STREQUAL "RPM" )
-            set ( CPACK_GENERATOR "${packageManagement}" )
+        ELSEIF ( ${packageManagement} STREQUAL "RPM" )
+            SET ( CPACK_GENERATOR "${packageManagement}" )
             ###
             ## CPack instruction required for RPM
             ###
-            message("-- Will build RPM package")
-            message ("-- Packing BASH installation files")
-            set ( CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/postinst" )
-            set ( CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/prerm" )
-            set ( CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/postrm" )
-        else()
-            message("WARNING: Unsupported package ${packageManagement}.")
-        endif ()
+            MESSAGE("-- Will build RPM package")
+            MESSAGE ("-- Packing BASH installation files")
+            SET ( CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/postinst" )
+            SET ( CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/prerm" )
+            SET ( CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/postrm" )
+        ELSE()
+            MESSAGE("WARNING: Unsupported package ${packageManagement}.")
+        ENDIF ()
 
-    endif ( CMAKE_SYSTEM MATCHES Linux )
-    if ( EXISTS ${CMAKE_MODULE_PATH}/dependencies/${packageRevision}.cmake )
-        include( ${CMAKE_MODULE_PATH}/dependencies/${packageRevision}.cmake )
-    else()
-        message("-- WARNING: DEPENDENCY FILE FOR ${packageRevision} NOT FOUND, Using deps template.")
-        include( ${CMAKE_MODULE_PATH}/dependencies/template.cmake )
-    endif()
-else()
-    message("WARNING: CMAKE 2.8.1 or later required to create RPMs from this project")
-endif()
+    ENDIF ( CMAKE_SYSTEM MATCHES Linux )
+    IF ( EXISTS ${CMAKE_MODULE_PATH}/dependencies/${packageRevision}.cmake )
+        INCLUDE( ${CMAKE_MODULE_PATH}/dependencies/${packageRevision}.cmake )
+    ELSE()
+        MESSAGE("-- WARNING: DEPENDENCY FILE FOR ${packageRevision} NOT FOUND, Using deps template.")
+        INCLUDE( ${CMAKE_MODULE_PATH}/dependencies/template.cmake )
+    ENDIF()
+ELSE()
+    MESSAGE("WARNING: CMAKE 2.8.1 or later required to create RPMs from this project")
+ENDIF()
 
-if ( NOT MAKE_DOCS_ONLY )
-
-    add_subdirectory (ecl)
-
-    #IF TARBALLED_HADOOP_PATH IS NOT PASSED IN, DEFAULT TO /usr/local/hadoop
-    #AT BUILD TIME THIS PATH WILL BE USED TO SEARCH FOR:
-    # ${TARBALLED_HADOOP_PATH}/src/c++/libhdfs/hdfs.h
-    # ${TARBALLED_HADOOP_PATH}/c++/${osdir}/libhdfs.so
-
-    #AT RUN TIME THIS PATH WILL BE USED TO SEARCH FOR:
-    # ${TARBALLED_HADOOP_PATH}/conf
-    # ${TARBALLED_HADOOP_PATH}/*.jar
-    # ${TARBALLED_HADOOP_PATH}/lib/*.jar
-
-    #####################################################
-    # hadoop install packages layout files in this manner:
-    # conf files  -> /etc/hadoop
-    # *.jar files -> /usr/share/hadoop & /usr/share/hadoop/lib
-    # hdfslib     -> /usr/lib or /usr/lib64
-    #####################################################
-
-    option(TARBALLED_HADOOP_PATH "Set the Hadoop path.")
-    if( NOT TARBALLED_HADOOP_PATH )
-        SET (TARBALLED_HADOOP_PATH "/usr/local/hadoop")
-    endif()
-
-    #set other paths
-    #generate config for script.
-    #add script processor for vars.
+IF ( NOT MAKE_DOCS_ONLY )
+    ADD_SUBDIRECTORY (ecl)
 
     SET ( HPCC_ETC_DIR "${CMAKE_INSTALL_PREFIX}/${OSSDIR}/etc")
     SET ( HPCC_CONF_DIR "${CMAKE_INSTALL_PREFIX}/${OSSDIR}${CONFIG_DIR}")
     SET ( HDFSCONN_CONF_FILE "hdfsconnector.conf" )
-    SET ( HDFSCONN_EXE_NAME "hdfsconnector" )
-    SET ( HDFSCONN_EXE_PATH "${EXEC_PATH}/${HDFSCONN_EXE_NAME}")
-
-    SET ( HADOOP_STD_CONF_PATH "/etc/hadoop" )
-    SET ( HADOOP_STD_SHARE_PATH "/usr/share/hadoop" )
-
-    find_package(JNI REQUIRED)
-    find_package(LIBHDFS REQUIRED)
-
-    configure_file("hdfsconnector.conf.in" "hdfsconnector.conf")
-    configure_file("postinst.in" "postinst")
-    configure_file("hdfspipe.in" "hdfspipe" @ONLY )
-
-    SET ( SRC hdfsconnector.cpp hdfsconnector.hpp)
-
-    include_directories (
-                          ${CMAKE_BINARY_DIR}
-                          ${CMAKE_BINARY_DIR}/oss
-                          ${JNI_INCLUDE_DIRS}
-                          ${JAVA_INCLUDE_PATH}
-                          ${JAVA_INCLUDE_PATH2}
-                          ${LIBHDFS_INCLUDE_DIR}  
-                         )
-
-    HPCC_ADD_EXECUTABLE( ${HDFSCONN_EXE_NAME} ${SRC} )
-
     SET ( INSTALLDIR "${OSSDIR}/bin")
-    Install ( TARGETS hdfsconnector DESTINATION ${INSTALLDIR} COMPONENT Runtime)
-    Install ( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/hdfspipe DESTINATION ${INSTALLDIR} COMPONENT Runtime )
-    Install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/hdfsconnector.conf DESTINATION ${HPCC_CONF_DIR}/rpmnew COMPONENT Runtime )
-    Install ( PROGRAMS h2h.install DESTINATION ${HPCC_ETC_DIR}/init.d/install COMPONENT Runtime )
 
-    target_link_libraries ( hdfsconnector
-                            ${JAVA_JVM_LIBRARY}
-                            ${LIBHDFS_LIBRARIES}
-                          )
+    MESSAGE ("-- Building ${HDFS_CONNECTOR_TYPE} --")
+    IF ( BUILD_WEBHDFS_VER )
+        SET ( HDFSCONN_EXE_NAME ${HDFS_CONNECTOR_TYPE} )
+        SET ( HDFSCONN_EXE_PATH "${EXEC_PATH}/${HDFSCONN_EXE_NAME}")
+
+        FIND_PACKAGE(CURL REQUIRED)
+
+        SET ( SRC hdfsconnector.hpp webhdfsconnector.cpp webhdfsconnector.hpp)
+
+        INCLUDE_DIRECTORIES ( ${CMAKE_BINARY_DIR} ${CURL_INCLUDE_DIR} )
+        HPCC_ADD_EXECUTABLE( ${HDFSCONN_EXE_NAME} ${SRC} )
+
+        INSTALL ( TARGETS ${HDFSCONN_EXE_NAME} DESTINATION ${INSTALLDIR} COMPONENT Runtime)
+
+        MESSAGE("-- LIBHDFDSCONNECTOR link libs:")
+        MESSAGE("--     ${HDFSCONN_EXE_NAME}")
+        MESSAGE("--      ${CURL_LIBRARY}")
+
+        TARGET_LINK_LIBRARIES ( ${HDFSCONN_EXE_NAME} ${CURL_LIBRARY} )
+
+    ELSE ()
+        SET ( HDFSCONN_EXE_NAME ${HDFS_CONNECTOR_TYPE} )
+        SET ( HDFSCONN_EXE_PATH "${EXEC_PATH}/${HDFSCONN_EXE_NAME}")
+
+        SET ( HADOOP_STD_CONF_PATH "/etc/hadoop" )
+        SET ( HADOOP_STD_SHARE_PATH "/usr/share/hadoop" )
+
+        OPTION(TARBALLED_HADOOP_PATH "Set the Hadoop path.")
+        IF( NOT TARBALLED_HADOOP_PATH )
+            SET (TARBALLED_HADOOP_PATH "/usr/local/hadoop")
+        ENDIF()
+
+        FIND_PACKAGE(JNI REQUIRED)
+        FIND_PACKAGE(LIBHDFS REQUIRED)
+
+        SET ( SRC hdfsconnector.hpp libhdfsconnector.cpp libhdfsconnector.hpp)
+
+        INCLUDE_DIRECTORIES (
+                      ${CMAKE_BINARY_DIR}
+                      ${CMAKE_BINARY_DIR}/oss
+                      ${JNI_INCLUDE_DIRS}
+                      ${JAVA_INCLUDE_PATH}
+                      ${JAVA_INCLUDE_PATH2}
+                      ${LIBHDFS_INCLUDE_DIR}
+                     )
+
+        HPCC_ADD_EXECUTABLE( ${HDFSCONN_EXE_NAME} ${SRC} )
+
+        INSTALL ( TARGETS ${HDFSCONN_EXE_NAME} DESTINATION ${INSTALLDIR} COMPONENT Runtime)
+
+        MESSAGE("-- LIBHDFDSCONNECTOR link libs:")
+        MESSAGE("--     ${JAVA_JVM_LIBRARY}")
+        MESSAGE("--     ${LIBHDFS_LIBRARIES}")
+        MESSAGE("--     ${HDFSCONN_EXE_NAME}")
+
+        TARGET_LINK_LIBRARIES ( ${HDFSCONN_EXE_NAME}
+                                ${JAVA_JVM_LIBRARY}
+                                ${LIBHDFS_LIBRARIES}
+                              )
+    ENDIF()
+
+    CONFIGURE_FILE("${HPCC_SOURCE_DIR}/hdfsconnector.conf.in" "hdfsconnector.conf")
+    CONFIGURE_FILE("${HPCC_SOURCE_DIR}/postinst.in" "postinst")
+    CONFIGURE_FILE("${HPCC_SOURCE_DIR}/hdfspipe.in" "${CMAKE_CURRENT_BINARY_DIR}/hdfspipe" @ONLY )
+
+    INSTALL ( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/hdfspipe DESTINATION ${INSTALLDIR} COMPONENT Runtime )
+    INSTALL ( FILES ${CMAKE_CURRENT_BINARY_DIR}/hdfsconnector.conf DESTINATION ${HPCC_CONF_DIR}/rpmnew COMPONENT Runtime )
+    INSTALL ( PROGRAMS ${HPCC_SOURCE_DIR}/h2h.install DESTINATION ${HPCC_ETC_DIR}/init.d/install COMPONENT Runtime )
 
     INCLUDE(CPack)
-endif()
-add_subdirectory(docs)
+ENDIF()
+
+ADD_SUBDIRECTORY(docs)

--- a/cmake_modules/dependencies/el5.cmake
+++ b/cmake_modules/dependencies/el5.cmake
@@ -1,2 +1,7 @@
 #centOS Redhat 5.x
-set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1.6.0-openjdk")
+
+IF ( BUILD_WEBHDFS_VER )
+	set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, curl")
+ELSE ()
+    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1.6.0-openjdk")
+ENDIF ()

--- a/cmake_modules/dependencies/el6.cmake
+++ b/cmake_modules/dependencies/el6.cmake
@@ -1,2 +1,6 @@
 #centOS Redhat 6.x
-set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1.6.0-openjdk")
+IF ( BUILD_WEBHDFS_VER )
+	set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, curl")
+ELSE ()
+    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1.6.0-openjdk")
+ENDIF ()

--- a/cmake_modules/dependencies/lenny.cmake
+++ b/cmake_modules/dependencies/lenny.cmake
@@ -1,2 +1,6 @@
 #Debian 5.x
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+IF ( BUILD_WEBHDFS_VER )
+	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3 ")
+ELSE ()
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+ENDIF ()

--- a/cmake_modules/dependencies/lucid.cmake
+++ b/cmake_modules/dependencies/lucid.cmake
@@ -1,2 +1,6 @@
 #ubuntu 10.04
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+IF ( BUILD_WEBHDFS_VER )
+	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3, libcurl3-nss")
+ELSE ()
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+ENDIF ()

--- a/cmake_modules/dependencies/natty.cmake
+++ b/cmake_modules/dependencies/natty.cmake
@@ -1,2 +1,6 @@
 #ubuntu 11.04
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+IF ( BUILD_WEBHDFS_VER )
+	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3, libcurl3-nss")
+ELSE ()
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+ENDIF ()

--- a/cmake_modules/dependencies/oneiric.cmake
+++ b/cmake_modules/dependencies/oneiric.cmake
@@ -1,2 +1,7 @@
 #ubuntu 11.10
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+IF ( BUILD_WEBHDFS_VER )
+	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3, libcurl3-nss")
+ELSE ()
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+    set ( CPACK_RPM_PACKAGE_CONFLICTS "hpccsystems-libhdfsconnector")
+ENDIF ()

--- a/cmake_modules/dependencies/precise.cmake
+++ b/cmake_modules/dependencies/precise.cmake
@@ -1,2 +1,6 @@
 #ubuntu 12.04
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+IF ( BUILD_WEBHDFS_VER )
+	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3, libcurl3-nss")
+ELSE ()
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+ENDIF ()

--- a/cmake_modules/dependencies/squeeze.cmake
+++ b/cmake_modules/dependencies/squeeze.cmake
@@ -1,2 +1,6 @@
 #Debian 6.x
-set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+IF ( BUILD_WEBHDFS_VER )
+	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, curl")
+ELSE ()
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+ENDIF ()

--- a/cmake_modules/dependencies/suse11.3.cmake
+++ b/cmake_modules/dependencies/suse11.3.cmake
@@ -1,1 +1,5 @@
-set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1_6_0-openjdk")
+IF ( BUILD_WEBHDFS_VER )
+	set ( CPACK_RPM_PACKAGE_REQUIRES  "hpccsystems-platform, libcurl4 ")
+ELSE ()
+    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1_6_0-openjdk")
+ENDIF ()

--- a/cmake_modules/dependencies/suse11.4.cmake
+++ b/cmake_modules/dependencies/suse11.4.cmake
@@ -1,1 +1,5 @@
-set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1_6_0-openjdk")
+IF ( BUILD_WEBHDFS_VER )
+	set ( CPACK_RPM_PACKAGE_REQUIRES  "hpccsystems-platform, libcurl4 ")
+ELSE ()
+    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1_6_0-openjdk")
+ENDIF ()

--- a/hdfsconnector.conf.in
+++ b/hdfsconnector.conf.in
@@ -15,7 +15,7 @@ HADOOP_SHARE_DIR=${HADOOP_STD_SHARE_PATH}
 #TARBALL_HADOOP_LOCATION = location of tarball hadoop instalation
 #If hadoop was not installed via deb/rpm install package
 #enable this var.
-#TARBALL_HADOOP_LOCATION=${TARBALLED_HADOOP_PATH}
+TARBALL_HADOOP_LOCATION=${TARBALLED_HADOOP_PATH}
 
 #H2H default libjvm location:
 # ${JAVA_JVM_LIBRARY}

--- a/hdfsconnector.hpp
+++ b/hdfsconnector.hpp
@@ -16,85 +16,357 @@
  along with this program. If not, see <http://www.gnu.org/licenses/>.
  ############################################################################## */
 
+#include <stdio.h>
 #include <string>
 #include <vector>
-#include <stdio.h>
 #include <iostream>
 #include <sstream>
 #include <fstream>
-#include "hdfs.h"
 
 using namespace std;
-
-using std::string;
-using std::vector;
 
 #define EOL "\n"
 #define RETURN_FAILURE -1
 
+enum HDFSConnectorAction
+{
+    HCA_INVALID = -1,
+    HCA_STREAMIN = 0,
+    HCA_STREAMOUT = 1,
+    HCA_STREAMOUTPIPE = 2,
+    HCA_READOUT = 3,
+    HCA_MERGEFILE = 4
+};
+
+struct HdfsFileStatus
+{
+   long accessTime;
+   int blockSize;
+   const char * group;
+   long length;
+   long modificationTime;
+   const char * owner;
+   const char * pathSuffix;
+   const char * permission;
+   int replication;
+   const char * type; //"FILE" | "DIRECTORY"
+};
+
+template <class T>
+inline string template2string (const T& anything)
+{
+    stringstream ss;
+    ss << anything;
+    return ss.str();
+}
 
 static inline void createFilePartName(string * filepartname, const char * filename, unsigned int nodeid, unsigned int clustercount)
 {
     filepartname->append(filename);
     filepartname->append("-parts/part_");
-    stringstream ss;
-    ss << nodeid;
-    filepartname->append(ss.str());
+    filepartname->append(template2string(nodeid));
     filepartname->append("_");
-    ss.str("");
-    ss << clustercount;
-    filepartname->append(ss.str());
+    filepartname->append(template2string(clustercount));
 }
 
-class Hdfs_Connector
+static void expandEscapedChars(const char * source, string & escaped)
 {
-private:
+    int si = 0;
 
-    hdfsFS fs;
-
- public:
-    Hdfs_Connector(const char * hadoopHost, unsigned short int hadoopPort, const char * hadoopUser)
+    while (source[si])
     {
-        fs = NULL;
-        if (strlen(hadoopUser) > 0)
-            fs = hdfsConnectAsUser(hadoopHost, hadoopPort, hadoopUser);
-        else
-            fs = hdfsConnect(hadoopHost, hadoopPort);
-
-        if (!fs)
+        if (source[si] == '\\')
         {
-            fprintf(stderr, "H2H Error: Could not connect to hdfs on %s:%d\n", hadoopHost, hadoopPort);
+            switch (source[++si])
+            {
+            case 'n':
+                escaped.append(1, '\n');
+                break;
+            case 'r':
+                escaped.append(1, '\r');
+                break;
+            case 't':
+                escaped.append(1, '\t');
+                break;
+            case 'b':
+                escaped.append(1, '\b');
+                break;
+            case 'v':
+                escaped.append(1, '\v');
+                break;
+            case 'f':
+                escaped.append(1, '\f');
+                break;
+            case '\\':
+                escaped.append(1, '\\');
+                break;
+            case '\'':
+                escaped.append(1, '\'');
+                break;
+            case '\"':
+                escaped.append(1, '\"');
+                break;
+            case '0':
+                escaped.append(1, '\0');
+                break;
+            case 'a':
+                escaped.append(1, '\a');
+                break;
+            case 'e':
+                escaped.append(1, '\e');
+                break;
+            default:
+                break;
+            }
         }
-    };
+        else
+            escaped.append(1, source[si]);
 
-    ~Hdfs_Connector()
+        si++;
+    }
+}
+class hdfsconnector
+{
+protected:
+    HDFSConnectorAction action;
+    unsigned int bufferSize;
+    unsigned int flushThreshold;
+    unsigned clusterCount;
+    unsigned nodeID;
+    unsigned long recLen;
+    unsigned long maxLen;
+    const char * fileName;
+    const char * hadoopHost;
+    int hadoopPort;
+    string format;
+    string foptions;
+    string data;
+    const char * wuid;
+    const char * rowTag;
+    const char * separator;
+    string terminator;
+    bool outputTerminator;
+    string quote;
+    const char * headerText;
+    const char * footerText;
+    const char * hdfsuser;
+    const char * hdfsgroup;
+    const char * pipepath;
+    bool cleanmerge;
+    short filereplication;
+    unsigned short maxRetry;
+    int blockSize;
+    bool verbose;
+public:
+    hdfsconnector() {};
+    hdfsconnector(int argc, char **argv)
     {
-        if (fs)
-            fprintf(stderr, "\nhdfsDisconnect returned: %d\n", hdfsDisconnect(fs));
-    };
+        parseInParams (argc, argv);
+    }
 
-    hdfsFS getHdfsFS();
-    tOffset getBlockSize(const char * filename);
-    long getFileSize(const char * filename);
-    long getRecordCount(long fsize, int clustersize, int reclen, int nodeid);
-    void ouputhosts(const char * rfile);
-    void outputFileInfo(hdfsFileInfo * fileInfo);
+    virtual ~hdfsconnector(){};
 
-    int readXMLOffset(const char * filename, unsigned long seekPos, unsigned long readlen, const char * rowTag,
-            const char * headerText, const char * footerText, unsigned long bufferSize);
-    int readCSVOffset(const char * filename, unsigned long seekPos, unsigned long readlen, const char * eolseq,
-            unsigned long bufferSize, bool outputTerminator, unsigned long recLen, unsigned long maxLen,
-            const char * quote);
-    int readFileOffset(const char * filename, tOffset seekPos, unsigned long readlen, unsigned long bufferSize);
-    int streamInFile(const char * rfile, int bufferSize);
-    int mergeFile(const char * filename, unsigned nodeid, unsigned clustercount, unsigned bufferSize,
-            unsigned flushthreshold, short filereplication, bool deleteparts);
-    int writeFlatOffset(const char * filename, unsigned nodeid, unsigned clustercount, const char * fileorpipename);
-    void escapedStringToChars(const char * source, string & escaped);
+    virtual bool connect() = 0;
+    virtual int  execute() = 0 ;
+    virtual int streamFileOffset() = 0;
+    virtual int writeFlatOffset() = 0;
+    virtual int mergeFile() = 0;
 
-private:
-    void getLastXMLElement(string * element, const char * xpath);
-    void getLastXPathElement(string * element, const char * xpath);
-    void getFirstXPathElement(string * element, const char * xpath);
-    void xpath2xml(string * xml, const char * xpath, bool open);
+    int parseInParams (int argc, char **argv)
+    {
+        int returnCode = EXIT_FAILURE;
+        int currParam = 1;
+
+        bufferSize = 1024 * 100;
+        flushThreshold = bufferSize * 10;
+        clusterCount = 0;
+        nodeID = 0;
+        recLen = 0;
+        maxLen = 0;
+        fileName = "";
+        hadoopHost = "default";
+        hadoopPort = 0;
+        format = "";
+        foptions = "";
+        data = "";
+
+        wuid = "";
+        rowTag = "Row";
+        separator = "";
+        terminator = EOL;
+        outputTerminator = true;
+        quote = "'";
+        headerText = "<Dataset>";
+        footerText = "</Dataset>";
+        hdfsuser = "";
+        hdfsgroup = "";
+        pipepath = "";
+        cleanmerge = false;
+        filereplication = 1;
+        maxRetry = 1;
+        blockSize = 0;
+        verbose = false;
+
+        action = HCA_INVALID;
+
+        while (currParam < argc)
+        {
+            if (strcmp(argv[currParam], "-si") == 0)
+            {
+                action = HCA_STREAMIN;
+                fprintf(stderr, "Action: HCA_STREAMIN\n");
+            }
+            else if (strcmp(argv[currParam], "-so") == 0)
+            {
+                action = HCA_STREAMOUT;
+                fprintf(stderr, "Action: HCA_STREAMOUT\n");
+            }
+            else if (strcmp(argv[currParam], "-sop") == 0)
+            {
+                action = HCA_STREAMOUTPIPE;
+                fprintf(stderr, "Action: HCA_STREAMOUTPIPE\n");
+            }
+            else if (strcmp(argv[currParam], "-mf") == 0)
+            {
+                action = HCA_MERGEFILE;
+                fprintf(stderr, "Action: HCA_MERGEFILE\n");
+            }
+            else if (strcmp(argv[currParam], "-clustercount") == 0)
+            {
+                clusterCount = atoi(argv[++currParam]);
+                fprintf(stderr, "clustercount: %d\n", clusterCount);
+            }
+            else if (strcmp(argv[currParam], "-nodeid") == 0)
+            {
+                nodeID = atoi(argv[++currParam]);
+                fprintf(stderr, "nodeID: %d\n", nodeID);
+            }
+            else if (strcmp(argv[currParam], "-reclen") == 0)
+            {
+                recLen = atol(argv[++currParam]);
+                fprintf(stderr, "recLen: %ld\n", recLen);
+            }
+            else if (strcmp(argv[currParam], "-format") == 0)
+            {
+                const char * tmp = argv[++currParam];
+                while (*tmp && *tmp != '(')
+                    format.append(1, *tmp++);
+                fprintf(stderr, "Format: %s\n", format.c_str());
+                if (*tmp++)
+                    while (*tmp && *tmp != ')')
+                        foptions.append(1, *tmp++);
+            }
+            else if (strcmp(argv[currParam], "-rowtag") == 0)
+            {
+                rowTag = argv[++currParam];
+            }
+            else if (strcmp(argv[currParam], "-filename") == 0)
+            {
+                fileName = argv[++currParam];
+                fprintf(stderr, "fileName: %s\n", fileName);
+            }
+            else if (strcmp(argv[currParam], "-host") == 0)
+            {
+                hadoopHost = argv[++currParam];
+                fprintf(stderr, "host: %s\n", hadoopHost);
+            }
+            else if (strcmp(argv[currParam], "-port") == 0)
+            {
+                hadoopPort = atoi(argv[++currParam]);
+                fprintf(stderr, "host: %d\n", hadoopPort);
+            }
+            else if (strcmp(argv[currParam], "-wuid") == 0)
+            {
+                wuid = argv[++currParam];
+            }
+            else if (strcmp(argv[currParam], "-data") == 0)
+            {
+                data.append(argv[++currParam]);
+            }
+            else if (strcmp(argv[currParam], "-separator") == 0)
+            {
+                separator = argv[++currParam];
+            }
+            else if (strcmp(argv[currParam], "-terminator") == 0)
+            {
+                terminator.clear();
+                expandEscapedChars(argv[++currParam], terminator);
+            }
+            else if (strcmp(argv[currParam], "-quote") == 0)
+            {
+                quote.clear();
+                expandEscapedChars(argv[++currParam], quote);
+            }
+            else if (strcmp(argv[currParam], "-headertext") == 0)
+            {
+                headerText = argv[++currParam];
+            }
+            else if (strcmp(argv[currParam], "-footertext") == 0)
+            {
+                footerText = argv[++currParam];
+            }
+            else if (strcmp(argv[currParam], "-buffsize") == 0)
+            {
+                bufferSize = atol(argv[++currParam]);
+            }
+            else if (strcmp(argv[currParam], "-outputterminator") == 0)
+            {
+                outputTerminator = atoi(argv[++currParam]);
+            }
+            else if (strcmp(argv[currParam], "-maxlen") == 0)
+            {
+                maxLen = atol(argv[++currParam]);
+            }
+            else if (strcmp(argv[currParam], "-hdfsuser") == 0)
+            {
+                hdfsuser = argv[++currParam];
+                fprintf(stderr, "hdfsuser: %s\n", hdfsuser);
+            }
+            else if (strcmp(argv[currParam], "-hdfsgroup") == 0)
+            {
+                hdfsgroup = argv[++currParam];
+                fprintf(stderr, "hdfsgroup: %s\n", hdfsgroup);
+            }
+            else if (strcmp(argv[currParam], "-pipepath") == 0)
+            {
+                pipepath = argv[++currParam];
+                fprintf(stderr, "pipepath: %s\n", pipepath);
+            }
+            else if (strcmp(argv[currParam], "-flushsize") == 0)
+            {
+                flushThreshold = atol(argv[++currParam]);
+                fprintf(stderr, "flushThreshold: %d\n", flushThreshold);
+            }
+            else if (strcmp(argv[currParam], "-cleanmerge") == 0)
+            {
+                cleanmerge = atoi(argv[++currParam]);
+                fprintf(stderr, "cleanmerge: %d\n", cleanmerge);
+            }
+            else if (strcmp(argv[currParam], "-hdfsfilereplication") == 0)
+            {
+                filereplication = atoi(argv[++currParam]);
+                fprintf(stderr, "hdfsfilereplication: %d\n", filereplication);
+            }
+            else if (strcmp(argv[currParam], "-whdfsretrymax") == 0)
+            {
+                maxRetry = atoi(argv[++currParam]);
+            }
+            else if (strcmp(argv[currParam], "-verbose") == 0)
+            {
+               verbose = atoi(argv[++currParam]);
+            }
+            else if (strcmp(argv[currParam], "-blocksize") == 0)
+            {
+                blockSize = atoi(argv[++currParam]);
+            }
+            else
+            {
+                fprintf(stderr, "Error: Found invalid input param: %s \n", argv[currParam]);
+                return returnCode;
+            }
+            currParam++;
+        }
+        return returnCode;
+    }
 };
+

--- a/hdfspipe.in
+++ b/hdfspipe.in
@@ -17,8 +17,8 @@
 #    along with All rights reserved. This program is free software: you can redistribute program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################
 
-#DO NOT CHANGE THIS FILE, CONFIGURATION CHANGES CAN BE DONE HERE:
-# /etc/HPCCSystems/@HDFSCONN_CONF_FILE@
+#DO NOT MODIFY THIS FILE!
+#CONFIGURATION CHANGES CAN BE DONE HERE: /etc/HPCCSystems/@HDFSCONN_CONF_FILE@
 
 source @HPCC_ETC_DIR@/init.d/hpcc_common
 set_environmentvars
@@ -27,6 +27,9 @@ source $configs/@HDFSCONN_CONF_FILE@
 
 CLASSPATH=$CLASSPATH:$HADOOP_CONF_DIR
 
+###################################################
+# CLASSPATH set up for libhdfs
+###################################################
 for f in $HADOOP_SHARE_DIR/*.jar ; do
     CLASSPATH=$CLASSPATH:$f
 done
@@ -69,7 +72,7 @@ done;
 #the log variable is read from the HPCC Platform config
 LOGS_LOCATION=$log
 HDFSCONNLOGLOC=$LOGS_LOCATION/mydataconnectors
-LOG=$HDFSCONNLOGLOC/HDFSCONNECTOR.$nodeid.$PID.log
+LOG=$HDFSCONNLOGLOC/@HDFS_CONNECTOR_TYPE@.$nodeid.$PID.log
 PIPERRLOG=$HDFSCONNLOGLOC/HPCC-FIFO.err.$PID
 
 if [ -e $HDFSCONNLOGLOC ]
@@ -88,18 +91,20 @@ echo "nodeid: $nodeid" 		>> $LOG
 h2hpid=0;
 h2hstatus=0;
 
+TARGETCONNECTORNAME="@HDFSCONN_EXE_NAME@";
+
 if [ "$1" = "" ];
 then
-	echo "Running without input params" >> $LOG
-	exit 1;
+    echo "Error: No input params detected!" >> $LOG
+    exit 1;
 elif [ $1 = "-mf" ];
 then
-    @HDFSCONN_EXE_PATH@ ${@}      2>> $LOG;
+    $TARGETCONNECTORNAME ${@}      2>> $LOG;
     h2hstatus=$?;
     h2hpid=$!;
 elif [ $1 = "-si" ];
 then
-    @HDFSCONN_EXE_PATH@  ${@}      2>> $LOG;
+    $TARGETCONNECTORNAME  ${@}      2>> $LOG;
     h2hstatus=$?
     h2hpid=$!;
 elif [ $1 = "-so" ];
@@ -120,7 +125,7 @@ then
 
     echo "calling hdfsconnector..."         >> $LOG
 
-    @HDFSCONN_EXE_PATH@ ${@} -pipepath $HPCCTMPFILE  	2>> $LOG
+    $TARGETCONNECTORNAME ${@} -pipepath $HPCCTMPFILE  	2>> $LOG
     h2hpid=$!;
     h2hstatus=$?;
 elif [ $1 = "-sop" ];
@@ -138,7 +143,7 @@ then
         echo "  WARNING (hdfsconnector mkfifo) error registered in file: $PIPERRLOG " >> $LOG
         exit 1
     fi
-    @HDFSCONN_EXE_PATH@  ${@} -pipepath $pipepath	2>> $LOG &
+    $TARGETCONNECTORNAME  ${@} -pipepath $pipepath	2>> $LOG &
 
     h2hpid=$!;
 
@@ -164,6 +169,6 @@ else
     h2hstatus=1;
 fi
 
-echo "H2H exited with: ${h2hstatus}"            >> $LOG
+echo "$TARGETCONNECTORNAME exited with: ${h2hstatus}"            >> $LOG
 
 exit ${h2hstatus};

--- a/libhdfsconnector.hpp
+++ b/libhdfsconnector.hpp
@@ -1,0 +1,93 @@
+/*##############################################################################
+
+ Copyright (C) 2012 HPCC Systems.
+
+ All rights reserved. This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as
+ published by the Free Software Foundation, either version 3 of the
+ License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ ############################################################################## */
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include "hdfs.h"
+
+#include "hdfsconnector.hpp"
+
+class libhdfsconnector : public hdfsconnector
+{
+
+private:
+
+    hdfsFS fs;
+
+ public:
+
+    libhdfsconnector(int argc, char **argv) : hdfsconnector(argc, argv)
+    {
+        fprintf(stderr, "\nCreating LIBHDFS based connector.\n");
+    }
+
+    ~libhdfsconnector()
+    {
+        if (fs)
+            fprintf(stderr, "\nhdfsDisconnect returned: %d\n", hdfsDisconnect(fs));
+    };
+
+    hdfsFS getHdfsFS();
+    tOffset getBlockSize(const char * filename);
+    long getFileSize(const char * filename);
+    long getRecordCount(long fsize, int clustersize, int reclen, int nodeid);
+    void ouputhosts(const char * rfile);
+    void outputFileInfo(hdfsFileInfo * fileInfo);
+
+    bool connect ();
+    int  execute ();
+
+    int readXMLOffset(const char * filename, unsigned long seekPos, unsigned long readlen, const char * rowTag,
+            const char * headerText, const char * footerText, unsigned long bufferSize);
+
+    int streamCSVFileOffset(
+            const char * filename,
+            unsigned long seekPos,
+            unsigned long readlen,
+            const char * eolseq,
+            unsigned long bufferSize,
+            bool outputTerminator,
+            unsigned long recLen,
+            unsigned long maxLen,
+            const char * quote,
+            int maxretries);
+
+    int streamFlatFileOffset(
+            const char * filename,
+            unsigned long seekPos,
+            unsigned long readlen,
+            unsigned long bufferSize,
+            int maxretries);
+
+    int streamInFile(const char * rfile, int bufferSize);
+
+    int mergeFile();
+
+    int writeFlatOffset();
+
+    int streamFileOffset();
+
+private:
+    void getLastXMLElement(string * element, const char * xpath);
+    void getLastXPathElement(string * element, const char * xpath);
+    void getFirstXPathElement(string * element, const char * xpath);
+    void xpath2xml(string * xml, const char * xpath, bool open);
+};

--- a/version.cmake
+++ b/version.cmake
@@ -1,9 +1,9 @@
 ###
 ## Version Information
 ###
-set ( HPCC_MAJOR 3 )
-set ( HPCC_MINOR 6 )
-set ( HPCC_POINT 4 )
+set ( HPCC_MAJOR 4 )
+set ( HPCC_MINOR 0 )
+set ( HPCC_POINT 0 )
 set ( HPCC_MATURITY "beta" )
 set ( HPCC_SEQUENCE 1 )
 ###

--- a/webhdfsconnector.cpp
+++ b/webhdfsconnector.cpp
@@ -1,0 +1,804 @@
+/*##############################################################################
+
+ Copyright (C) 2012 HPCC Systems.
+
+ All rights reserved. This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as
+ published by the Free Software Foundation, either version 3 of the
+ License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ ############################################################################## */
+
+#include "webhdfsconnector.hpp"
+
+int webhdfsconnector::reachWebHDFS()
+{
+    int retval = RETURN_FAILURE;
+
+    if (!curl)
+    {
+        fprintf(stderr, "Could not reach WebHDFS\n");
+        return retval;
+    }
+
+    curl_easy_reset(curl);
+
+    string filestatusstr;
+
+    string getFileStatus;
+    getFileStatus.append(baseurl);
+    getFileStatus.append("?op=GETFILESTATUS");
+
+    fprintf(stderr, "Testing connection: %s\n", getFileStatus.c_str());
+    curl_easy_setopt(curl, CURLOPT_URL, getFileStatus.c_str());
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
+
+    //Dont' use default curl WRITEFUNCTION bc it outputs value to STDOUT.
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToStrCallBackCurl);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &filestatusstr);
+
+    CURLcode res = curl_easy_perform(curl);
+
+    if (res == CURLE_OK)
+        retval = EXIT_SUCCESS;
+    else
+        fprintf(stderr, "Could not reach WebHDFS\n");
+
+    return retval;
+}
+
+unsigned long webhdfsconnector::getFileSize(const char * fileurl)
+{
+    HdfsFileStatus filestat;
+
+    if (getFileStatus(fileurl, &filestat) != RETURN_FAILURE)
+        return filestat.length;
+    else
+        return 0;
+}
+
+unsigned long webhdfsconnector::getFileSize()
+{
+    return targetfilestatus.length;
+}
+
+int webhdfsconnector::getFileStatus(const char * fileurl, HdfsFileStatus * filestat)
+{
+    int retval = RETURN_FAILURE;
+
+    if (!curl)
+    {
+        fprintf(stderr, "Could not connect to WebHDFS\n");
+        return retval;
+    }
+
+    string filestatusstr;
+    string requestheader;
+
+    string getFileStatus;
+    getFileStatus.append(fileurl);
+
+    if (hasUserName())
+    {
+        getFileStatus.append("?user.name=");
+        getFileStatus.append(username);
+        getFileStatus.append("&op=GETFILESTATUS");
+    }
+    else
+        getFileStatus.append("?op=GETFILESTATUS");
+
+    curl_easy_reset(curl);
+
+    fprintf(stderr, "Retrieving file status: %s\n", getFileStatus.c_str());
+
+    curl_easy_setopt(curl, CURLOPT_URL, getFileStatus.c_str());
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToStrCallBackCurl);
+
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &filestatusstr);
+
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToStrCallBackCurl);
+    curl_easy_setopt(curl, CURLOPT_WRITEHEADER, &requestheader);
+
+    CURLcode res = curl_easy_perform(curl);
+
+    if (res == CURLE_OK)
+    {
+
+        try
+        {
+            /*
+             * Not using JSON parser to avoid 3rd party deps
+             */
+
+            filestat->accessTime = -1;
+            filestat->blockSize = -1;
+            filestat->group = "";
+            filestat->length = -1;
+            filestat->modificationTime = -1;
+            filestat->owner = "";
+            filestat->pathSuffix = "";
+            filestat->permission = "";
+            filestat->replication = -1;
+            filestat->type = "";
+
+            fprintf(stderr, "%s.\n", filestatusstr.c_str());
+
+            if (filestatusstr.find("FileStatus") >=0 )
+            {
+                int lenpos = filestatusstr.find("length");
+                if (lenpos >= 0)
+                {
+                    int colpos = filestatusstr.find_first_of(':', lenpos);
+                    if (colpos > lenpos)
+                    {
+                        int compos = filestatusstr.find_first_of(',', colpos);
+                        if (compos > colpos)
+                        {
+                            filestat->length = atol(filestatusstr.substr(colpos+1,compos-1).c_str());
+                        }
+                    }
+                }
+            }
+
+            retval = EXIT_SUCCESS;
+        }
+        catch (...) {}
+
+        if (retval != EXIT_SUCCESS)
+            fprintf(stderr, "Error fetching HDFS file status.\n");
+    }
+    return retval;
+}
+
+int webhdfsconnector::streamFlatFileOffset(unsigned long seekPos, unsigned long readlen, int maxretries)
+{
+    int retval = RETURN_FAILURE;
+
+    if (!curl)
+    {
+        fprintf(stderr, "Could not connect to WebHDFS\n");
+        return retval;
+    }
+
+    curl_easy_reset(curl);
+    string readfileurl;
+    string requestheader;
+
+    readfileurl.append(targetfileurl).append("?");
+    if (hasUserName())
+        readfileurl.append("user.name=").append(username).append("&");
+
+    readfileurl.append("op=OPEN&offset=");
+    readfileurl.append(template2string(seekPos));
+    readfileurl.append("&length=");
+    readfileurl.append(template2string(readlen));
+
+    fprintf(stderr, "Reading file data: %s\n", readfileurl.c_str());
+
+    CURLcode res;
+    int failed_attempts = 0;
+    double dlsize = 0;
+    double tottime = 0;
+    double dlspeed = 0;
+
+    do
+    {
+        curl_easy_setopt(curl, CURLOPT_URL, readfileurl.c_str());
+        curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);
+        curl_easy_setopt(curl, CURLOPT_VERBOSE, true);
+
+        res = curl_easy_perform(curl);
+
+        if (res == CURLE_OK)
+        {
+            curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD, &dlsize);
+            curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME, &tottime);
+            curl_easy_getinfo(curl, CURLINFO_SPEED_DOWNLOAD, &dlspeed);
+        }
+        else
+        {
+            failed_attempts++;
+            fprintf(stderr, "Error attempting to read from HDFS file: \n\t%s\n", readfileurl.c_str());
+        }
+    }
+    while(res != CURLE_OK && failed_attempts <= maxretries);
+
+    if (res == CURLE_OK)
+    {
+        retval = EXIT_SUCCESS;
+        fprintf(stderr, "\nPipe in FLAT file results:\n");
+        fprintf(stderr, "Read time: %.3f secs\t ", tottime);
+        fprintf(stderr, "Read speed: %.0f bytes/sec\n", dlspeed);
+        fprintf(stderr, "Read size: %.0f bytes\n", dlsize);
+    }
+
+    return retval;
+}
+
+int webhdfsconnector::streamCSVFileOffset(unsigned long seekPos,
+        unsigned long readlen, const char * eolseq, unsigned long bufferSize, bool outputTerminator,
+        unsigned long recLen, unsigned long maxLen, const char * quote, int maxretries)
+{
+    fprintf(stderr, "CSV terminator: \'%s\' and quote: \'%c\'\n", eolseq, quote[0]);
+    unsigned long recsFound = 0;
+
+    unsigned eolseqlen = strlen(eolseq);
+    if (seekPos > eolseqlen)
+        seekPos -= eolseqlen; //read back sizeof(EOL) in case the seekpos happens to be a the first char after an EOL
+
+    bool withinQuote = false;
+
+    string bufferstr ="";
+    bufferstr.resize(bufferSize);
+
+    bool stopAtNextEOL = false;
+    bool firstEOLfound = seekPos == 0;
+
+    unsigned long currentPos = seekPos;
+
+    fprintf(stderr, "--Start looking: %ld--\n", currentPos);
+
+    unsigned long bytesLeft = readlen;
+
+    const char * buffer;
+
+    curl_easy_reset(curl);
+
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, true);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToStrCallBackCurl);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &bufferstr);
+
+    while(bytesLeft > 0)
+    {
+        bufferstr.clear();
+        double num_read_bytes = readTargetFileOffsetToBuffer(currentPos, bytesLeft > bufferSize ? bufferSize : bytesLeft, maxretries);
+
+        if (num_read_bytes <= 0)
+        {
+            fprintf(stderr, "\n--Hard Stop at: %ld--\n", currentPos);
+            break;
+        }
+
+        buffer = bufferstr.c_str();
+
+        for (int bufferIndex = 0; bufferIndex < num_read_bytes; bufferIndex++, currentPos++)
+        {
+            char currChar = buffer[bufferIndex];
+
+            if (currChar == EOF)
+                break;
+
+            if (currChar == quote[0])
+            {
+                fprintf(stderr, "found quote char at pos: %ld\n", currentPos);
+                withinQuote = !withinQuote;
+            }
+
+            if (currChar == eolseq[0] && !withinQuote)
+            {
+                bool eolfound = true;
+                double extraNumOfBytesRead = 0;
+                string tmpstr("");
+
+                if (eolseqlen > 1)
+                {
+                    int eoli = bufferIndex;
+                    while (eoli < num_read_bytes && eoli - bufferIndex < eolseqlen)
+                    {
+                        tmpstr.append(1, buffer[eoli++]);
+                    }
+
+                    if (eoli == num_read_bytes && tmpstr.size() < eolseqlen)
+                    {
+                        //looks like we have to do a remote read, but before we do, let's make sure the substring matches
+                        if (strncmp(eolseq, tmpstr.c_str(), tmpstr.size())==0)
+                        {
+                            string tmpbuffer = "";
+                            curl_easy_setopt(curl, CURLOPT_WRITEDATA, &tmpbuffer);
+                            //TODO have to make a read... of eolseqlen - tmpstr.size is it worth it?
+                            //read from the current position scanned on the file (currentPos) + number of char looked ahead for eol (eoli - bufferIndex)
+                            //up to the necessary chars to determine if we're currently scanning the EOL sequence (eolseqlen - tmpstr.size()
+
+                            extraNumOfBytesRead = readTargetFileOffsetToBuffer(currentPos + (eoli - bufferIndex), eolseqlen - tmpstr.size(), maxretries);
+                            for(int y = 0; y < extraNumOfBytesRead; y++)
+                                tmpstr.append(1, tmpbuffer.at(y));
+
+                            curl_easy_setopt(curl, CURLOPT_WRITEDATA, &bufferstr);
+                        }
+                    }
+
+                    if (strcmp(tmpstr.c_str(), eolseq) != 0)
+                        eolfound = false;
+                }
+
+                if (eolfound)
+                {
+                    if (!firstEOLfound)
+                    {
+                        bufferIndex = bufferIndex + eolseqlen - 1;
+                        currentPos = currentPos + eolseqlen - 1;
+                        bytesLeft = bytesLeft - eolseqlen;
+
+                        fprintf(stderr, "\n--Start reading: %ld --\n", currentPos);
+
+                        firstEOLfound = true;
+                        continue;
+                    }
+
+                    if (outputTerminator)
+                    {
+                        fprintf(stdout, "%s", eolseq);
+
+                        bufferIndex += eolseqlen;
+                        currentPos += eolseqlen;
+                        bytesLeft -= eolseqlen;
+                    }
+
+                    recsFound++;
+
+                    if (stopAtNextEOL)
+                    {
+                        fprintf(stderr, "\n--Stop piping: %ld--\n", currentPos);
+                        bytesLeft = 0;
+                        break;
+                    }
+
+                    if (bufferIndex < num_read_bytes)
+                        currChar = buffer[bufferIndex];
+                    else
+                        break;
+                }
+            }
+
+            //don't pipe until we're beyond the first EOL (if offset = 0 start piping ASAP)
+            if (firstEOLfound)
+            {
+                fprintf(stdout, "%c", currChar);
+                bytesLeft--;
+            }
+            else
+            {
+                fprintf(stderr, "%c", currChar);
+                bytesLeft--;
+                if(maxLen > 0 && currentPos-seekPos > maxLen * 10)
+                {
+                    fprintf(stderr, "\nFirst EOL was not found within the first %ld bytes", currentPos-seekPos);
+                    return EXIT_FAILURE;
+                }
+            }
+
+            if (stopAtNextEOL)
+                fprintf(stderr, "%c", currChar);
+
+            // If bytesLeft <= 0 at this point, but he haven't encountered
+            // the last EOL, need to continue piping untlil EOL is encountered.
+            if (bytesLeft <= 0  && currChar != eolseq[0])
+            {
+                if(!firstEOLfound)
+                {
+                    fprintf(stderr, "\n--Reached end of readlen before finding first record start at: %ld (breaking out)--\n",  currentPos);
+                    break;
+                }
+
+                if (stopAtNextEOL)
+                {
+                    fprintf(stderr, "Could not find last EOL, breaking out a position %ld\n", currentPos);
+                    break;
+                }
+
+                fprintf(stderr, "\n--Looking for Last EOL: %ld --\n", currentPos);
+                bytesLeft = maxLen; //not sure how much longer until next EOL read up max record len;
+                stopAtNextEOL = true;
+            }
+        }
+    }
+
+    fprintf(stderr, "\nCurrentPos: %ld, RecsFound: %ld\n", currentPos, recsFound);
+
+    if (currentPos == seekPos && readlen > 0 )
+    {
+       fprintf(stderr, "\n--ERROR  0 Bytes Fetched--\n");
+       return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+double webhdfsconnector::readTargetFileOffsetToBuffer(unsigned long seekPos, unsigned long readlen, int maxretries)
+{
+    double returnval = 0;
+
+    if (!curl)
+    {
+        fprintf(stderr, "Could not connect to WebHDFS");
+        return returnval;
+    }
+
+    char readfileurl [1024];
+    if (hasUserName())
+        sprintf(readfileurl, "%s?user.name=%s&op=OPEN&offset=%lu&length=%lu",targetfileurl.c_str(), username.c_str(), seekPos,readlen);
+    else
+        sprintf(readfileurl, "%s?op=OPEN&offset=%lu&length=%lu",targetfileurl.c_str(), seekPos,readlen);
+
+    curl_easy_setopt(curl, CURLOPT_URL, readfileurl);
+
+    CURLcode res;
+    int failed_attempts = 0;
+    do
+    {
+        res = curl_easy_perform(curl);
+
+        if (res == CURLE_OK)
+        {
+            double dlsize;
+            curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD, &dlsize);
+            if (dlsize > readlen)
+                fprintf(stderr, "Warning: received incorrect number of bytes from HDFS.\n");
+            else
+                returnval = dlsize;
+        }
+        else
+        {
+            failed_attempts++;
+            fprintf(stderr, "Error attempting to read from HDFS file: \n\t%s\n", readfileurl);
+        }
+    }
+    while(res != CURLE_OK && failed_attempts <= maxretries);
+
+    return returnval;
+}
+
+unsigned long webhdfsconnector::getTotalFilePartsSize(unsigned clustercount)
+{
+    unsigned long totalSize = 0;
+
+    for (unsigned node = 0; node < clustercount; node++)
+    {
+        char filepartname[1024];
+        memset(&filepartname[0], 0, sizeof(filepartname));
+        sprintf(filepartname,"%s-parts/part_%d_%d", targetfileurl.c_str(), node, clustercount);
+
+        unsigned long partFileSize = getFileSize(filepartname);
+
+        if (partFileSize <= 0)
+        {
+            fprintf(stderr,"Error: Could not find part file: %s", filepartname);
+            return 0;
+        }
+
+        totalSize += partFileSize;
+    }
+
+    return totalSize;
+}
+
+unsigned long webhdfsconnector::appendBufferOffset(long blocksize, short replication, int buffersize, unsigned char * buffer)
+{
+    //curl -i -X POST "http://<HOST>:<PORT>/webhdfs/v1/<PATH>?op=APPEND[&buffersize=<INT>]"
+
+    unsigned long retval = RETURN_FAILURE;
+
+    if (!curl)
+    {
+        fprintf(stderr, "Could not connect to WebHDFS");
+        return retval;
+    }
+
+    curl_easy_reset(curl);
+
+    char openfileurl [1024];
+    if (hasUserName())
+        sprintf(openfileurl, "%s?user.name=%s&op=APPEND&buffersize=%d",targetfileurl.c_str(), username.c_str(), buffersize);
+    else
+        sprintf(openfileurl, "%s?op=APPEND&buffersize=%d",targetfileurl.c_str(), buffersize);
+
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, continueCallBackCurl);
+    curl_easy_setopt(curl, CURLOPT_URL, openfileurl);
+    curl_easy_setopt(curl, CURLOPT_POST, true);
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, false);
+
+    string header;
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToStrCallBackCurl);
+    curl_easy_setopt(curl,   CURLOPT_WRITEHEADER, &header);
+
+    CURLcode res = curl_easy_perform(curl);
+
+    if (res == CURLE_OK)
+    {
+        size_t found;
+        found = header.find("307 TEMPORARY_REDIRECT");
+
+        if (found!=string::npos)
+        {
+            found=header.find("Location:",found+22);
+            if (found!=string::npos)
+            {
+                size_t  eolfound =header.find(EOL,found);
+                string tmp = header.substr(found+10,eolfound-(found+10) - strlen(EOL));
+
+                curl_easy_setopt(curl, CURLOPT_URL, tmp.c_str());
+
+                curl_easy_setopt(curl, CURLOPT_POST, true);
+                curl_easy_setopt(curl, CURLOPT_READFUNCTION, readBufferCallBackCurl);
+                curl_easy_setopt(curl, CURLOPT_READDATA, buffer);
+                curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, buffersize);
+                curl_easy_setopt(curl, CURLOPT_VERBOSE, false);
+
+                header.clear();
+                curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToStrCallBackCurl);
+                curl_easy_setopt(curl,   CURLOPT_WRITEHEADER, &header);
+
+                res = curl_easy_perform(curl);
+
+                fprintf(stderr, "Response: %s\n", header.c_str());
+            }
+        }
+    }
+
+    if (res != CURLE_OK)
+        fprintf(stderr, "Error transferring file. Curl error code: %d\n", res);
+    else
+        retval = buffersize;
+
+    return retval;
+}
+
+bool webhdfsconnector::connect ()
+{
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+    curl = curl_easy_init();
+
+    if (!curl)
+    {
+        fprintf(stderr, "Could not connect to WebHDFS\n");
+        return false;
+    }
+
+    baseurl.clear();
+    targetfileurl.clear();
+    hasusername = false;
+
+    baseurl.append(hadoopHost);
+    baseurl.append(":");
+    baseurl.append(template2string(hadoopPort));
+    baseurl.append(WEBHDFS_VER_PATH);
+
+    targetfileurl.assign(baseurl.c_str());
+    baseurl.append("/");
+    if (fileName[0] != '/')
+        targetfileurl.append("/");
+
+    targetfileurl.append(fileName);
+
+    if (strlen(hdfsuser)>0)
+    {
+        username.assign(hdfsuser);
+        hasusername = true;
+    }
+
+    webhdfsreached = (reachWebHDFS() == EXIT_SUCCESS);
+
+    if (webhdfsreached)
+        getFileStatus(targetfileurl.c_str(), &targetfilestatus);
+
+    return webhdfsreached;
+};
+
+int webhdfsconnector::execute ()
+{
+    int returnCode = EXIT_FAILURE;
+
+    if (action == HCA_STREAMIN)
+    {
+       returnCode = streamFileOffset();
+    }
+    else if (action == HCA_STREAMOUT || action == HCA_STREAMOUTPIPE)
+    {
+        returnCode = writeFlatOffset();
+    }
+    else if (action == HCA_MERGEFILE)
+    {
+        returnCode = mergeFile();
+    }
+    else
+    {
+        fprintf(stderr, "\nNo action type detected, exiting.");
+    }
+    return returnCode;
+};
+
+int webhdfsconnector::streamInFile(const char * rfile, int bufferSize)
+{
+    return 0;
+}
+
+int webhdfsconnector::mergeFile()
+{
+    fprintf(stderr, "Merging of file parts not supported by WEBHDFS version of HDFSConnector!\n");
+    return RETURN_FAILURE;
+}
+
+int webhdfsconnector::writeFlatOffset()
+{
+    int retval = RETURN_FAILURE;
+
+     if (strlen(pipepath) <= 0)
+     {
+         fprintf(stderr, "Bad data pipe or file name found");
+         return retval;
+     }
+
+     if (!curl)
+     {
+         fprintf(stderr, "Could not connect to WebHDFS");
+         return retval;
+     }
+
+     curl_easy_reset(curl);
+
+     char openfileurl [1024];
+     if (hasUserName())
+         sprintf(openfileurl, "%s-parts/part_%d_%d?user.name=%s&op=CREATE&replication=%d&overwrite=true",targetfileurl.c_str(),nodeID, clusterCount,username.c_str(), 1);
+     else
+         sprintf(openfileurl, "%s-parts/part_%d_%d?op=CREATE&replication=%d&overwrite=true",targetfileurl.c_str(),nodeID, clusterCount, 1);
+
+     _IO_FILE * datafileorpipe;
+     datafileorpipe = fopen(pipepath, "rb");
+
+     fprintf(stderr, "Setting up new HDFS file: %s\n", openfileurl);
+
+     curl_easy_setopt(curl, CURLOPT_READFUNCTION, continueCallBackCurl);
+     curl_easy_setopt(curl, CURLOPT_READDATA, datafileorpipe);
+     curl_easy_setopt(curl, CURLOPT_URL, openfileurl);
+     curl_easy_setopt(curl, CURLOPT_PUT, true);
+     curl_easy_setopt(curl, CURLOPT_VERBOSE, true);
+     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, false);
+
+     string header;
+     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToStrCallBackCurl);
+     curl_easy_setopt(curl,   CURLOPT_WRITEHEADER, &header);
+
+     CURLcode res = curl_easy_perform(curl);
+
+     if (res == CURLE_OK)
+     {
+         size_t found;
+         found = header.find_first_of("307 TEMPORARY_REDIRECT");
+ //        HTTP/1.1 100 Continue\\r\\n\\r\\nHTTP/1.1 307 TEMPORARY_REDIRECT\\r\\nContent-Type: application/json\\r\\nExpires: Thu, 01-Jan-1970 00:00:00 GMT\\r\\nSet-Cookie: hadoop.auth=\\"u=hadoop&p=hadoop&t=simple&e=1345504538799&s=
+         if (found!=string::npos)
+         {
+             found=header.find("Location:",found+22);
+             if (found!=string::npos)
+             {
+                 size_t  eolfound =header.find(EOL,found);
+                 string tmp = header.substr(found+10,eolfound-(found+10) - strlen(EOL));
+                 fprintf(stderr, "Redirect location: %s\n", tmp.c_str());
+
+                 curl_easy_setopt(curl, CURLOPT_URL, tmp.c_str());
+                 curl_easy_setopt(curl, CURLOPT_UPLOAD, true);
+                 curl_easy_setopt(curl, CURLOPT_READFUNCTION, readFileCallBackCurl);
+                 curl_easy_setopt(curl, CURLOPT_READDATA, datafileorpipe);
+
+                 string errorbody;
+                 curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToStrCallBackCurl);
+                 curl_easy_setopt(curl,   CURLOPT_WRITEDATA, &errorbody);
+
+                 res = curl_easy_perform(curl);
+                 if (res == CURLE_OK)
+                 {
+                     if (errorbody.length() > 0)
+                         fprintf(stderr, "Error transferring file: %s\n", errorbody.c_str());
+                     else
+                         retval = EXIT_SUCCESS;
+                 }
+                 else
+                 {
+                     fprintf(stderr, "Error transferring file. Curl error code: %d\n", res);
+                 }
+             }
+         }
+     }
+     else
+     {
+         fprintf(stderr, "Error setting up file: %s.\n", openfileurl);
+     }
+
+     return retval;
+}
+
+int webhdfsconnector::streamFileOffset()
+{
+    int returnCode = RETURN_FAILURE;
+
+    fprintf(stderr, "\nStreaming in %s...\n", fileName);
+
+    unsigned long fileSize = getFileSize();
+
+    if (fileSize != RETURN_FAILURE)
+    {
+        if (strcmp(format.c_str(), "FLAT") == 0)
+        {
+            unsigned long recstoread = getRecordCount(fileSize, clusterCount, recLen, nodeID);
+            if (recstoread != RETURN_FAILURE)
+            {
+                unsigned long totRecsInFile = fileSize / recLen;
+                unsigned long offset = nodeID * (totRecsInFile / clusterCount) * recLen;
+                unsigned long leftOverRecs = totRecsInFile % clusterCount;
+
+                if (leftOverRecs > 0)
+                {
+                    if (leftOverRecs > nodeID)
+                        offset += nodeID * recLen;
+                    else
+                        offset += leftOverRecs * recLen;
+                }
+
+                fprintf(stderr, "fileSize: %lu offset: %lu size bytes: %lu, recstoread:%lu\n", fileSize, offset,
+                        recstoread * recLen, recstoread);
+
+                if (offset < fileSize)
+                    returnCode = streamFlatFileOffset(offset, recstoread * recLen, maxRetry);
+            }
+            else
+                fprintf(stderr, "Could not determine number of records to read");
+        }
+
+        else if (strcmp(format.c_str(), "CSV") == 0)
+        {
+            fprintf(stderr, "Filesize: %ld, Offset: %ld, readlen: %ld\n", fileSize,
+                    (fileSize / clusterCount) * nodeID, fileSize / clusterCount);
+
+            returnCode = streamCSVFileOffset((fileSize / clusterCount) * nodeID,
+                    fileSize / clusterCount, terminator.c_str(), bufferSize, outputTerminator, recLen, maxLen,
+                    quote.c_str(), maxRetry);
+        }
+        else
+            fprintf(stderr, "Unknown format type: %s(%s)", format.c_str(), foptions.c_str());
+    }
+    else
+        fprintf(stderr, "Could not determine HDFS file size: %s", fileName);
+
+    return returnCode;
+}
+
+long webhdfsconnector::getRecordCount(long fsize, int clustersize, int reclen, int nodeid)
+{
+    long readSize = fsize / reclen / clustersize;
+    if (fsize % reclen)
+    {
+        fprintf(stderr, "filesize (%lu) not multiple of record length(%d)", fsize, reclen);
+        return RETURN_FAILURE;
+    }
+
+    if ((fsize / reclen) % clustersize > nodeid)
+    {
+        readSize++;
+        fprintf(stderr, "\nThis node will pipe one extra rec\n");
+    }
+    return readSize;
+}
+
+int main(int argc, char **argv)
+{
+    int returnCode = EXIT_FAILURE;
+
+    webhdfsconnector * connector = new webhdfsconnector(argc, argv);
+
+    if (connector->connect())
+    {
+        returnCode = connector->execute();
+    }
+
+    if (connector)
+        delete (connector);
+
+    return returnCode;
+}

--- a/webhdfsconnector.hpp
+++ b/webhdfsconnector.hpp
@@ -1,0 +1,152 @@
+/*##############################################################################
+
+ Copyright (C) 2012 HPCC Systems.
+
+ All rights reserved. This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as
+ published by the Free Software Foundation, either version 3 of the
+ License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ ############################################################################## */
+
+#include <stdio.h>
+#include <string.h>
+#include <sstream>
+#include <stdlib.h>
+#include <curl/curl.h>
+
+#include "hdfsconnector.hpp"
+
+#define WEBHDFS_VER_PATH "/webhdfs/v1"
+
+static size_t readStringCallBackCurl(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    size_t retcode = 0;
+    curl_off_t nread;
+
+    if (stream && ((string *)stream)->size() > 0)
+    {
+        retcode = sprintf((char*)ptr, "%s", ((string *)stream)->c_str());
+        ((string *)stream)->clear();
+    }
+
+    return retcode;
+}
+
+static size_t readBufferCallBackCurl(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    size_t retcode = 0;
+    curl_off_t nread;
+
+    if (stream && strlen((char *)stream) > 0)
+    {
+        retcode = sprintf((char*)ptr, "%s", (char *)stream);
+        ((char *)stream)[0] = '\0';
+    }
+
+    return retcode;
+}
+
+static size_t continueCallBackCurl(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    return 0;
+}
+
+static size_t readFileCallBackCurl(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    size_t retcode;
+    curl_off_t nread;
+
+    retcode = fread(ptr, size, nmemb, (_IO_FILE *)stream);
+
+  return retcode;
+}
+
+static size_t writeToBufferCurl(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    if (stream)
+        sprintf((char *)stream, "%s", (char*)ptr);
+
+    return size*nmemb;
+}
+
+static size_t writeToStrCallBackCurl( void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    if (stream)
+    {
+        ((std::string *)stream)->append((char*)ptr, size*nmemb);
+    }
+    return size*nmemb;
+}
+
+static size_t writeToStdOutCallBackCurl( void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    fprintf(stdout, "%s", (char*)ptr);
+    return size*nmemb;
+}
+
+static size_t writeToStdErrCallBackCurl( void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    fprintf(stderr, "%s", (char*)ptr);
+    return size*nmemb;
+}
+
+class webhdfsconnector : public hdfsconnector
+{
+private:
+    string baseurl;
+    string targetfileurl;
+    string username;
+    bool hasusername;
+    bool webhdfsreached;
+    CURL *curl;
+
+    HdfsFileStatus targetfilestatus;
+
+public:
+
+    webhdfsconnector(int argc, char **argv) : hdfsconnector(argc, argv)
+    {
+        fprintf(stderr, "\nCreating WEBBHDFS based connector.\n");
+    }
+
+    ~webhdfsconnector()
+    {
+        curl_easy_cleanup(curl);
+    };
+
+    bool connect ();
+    int  execute ();
+
+    int streamInFile(const char * rfile, int bufferSize);
+    int mergeFile();
+    int writeFlatOffset();
+    int streamFileOffset();
+    int reachWebHDFS();
+    int streamFlatFileOffset(unsigned long seekPos, unsigned long readlen, int maxretries);
+    int streamCSVFileOffset(unsigned long seekPos,
+            unsigned long readlen, const char * eolseq, unsigned long bufferSize, bool outputTerminator,
+            unsigned long recLen, unsigned long maxLen, const char * quote, int maxretries);
+
+    unsigned long getTotalFilePartsSize(unsigned clustercount);
+
+    double readTargetFileOffsetToBuffer(unsigned long seekPos, unsigned long readlen, int maxretries);
+
+    int getFileStatus(const char * fileurl, HdfsFileStatus * filestat);
+    unsigned long appendBufferOffset(long blocksize, short replication, int buffersize, unsigned char * buffer);
+
+    unsigned long getFileSize();
+    unsigned long getFileSize(const char * url);
+
+    long getRecordCount(long fsize, int clustersize, int reclen, int nodeid);
+
+    bool hasUserName(){return hasusername;}
+    bool webHdfsReached(){return webhdfsreached;}
+};


### PR DESCRIPTION
Two separate packages can be built, libhdfs and webhdfs based.
By default, libhdfs is built, to build webhdfs set BUILD_WEBHDFS_VER=ON.
The package name will contain the build type, and target executable will
be named based on the underlying technology. ie libhdfsconnector, or
webhdfsconnector.
Pipehdfs will attempt to execute either libhdfsconnector, or webhdfsconnector
based on originating package.
Version moves to 4.0.0Beta.
Webhdfs version requires HPCCplatorm and libcurl.
Install dependencies are based on value of above flag.

Signed-off-by: Rodrigo Pastrana Rodrigo.Pastrana@lexisnexis.com
