### PR TITLE
HH-93 Remove Hadoop as dependancy

### DIFF
--- a/cmake_modules/dependencies/el5.cmake
+++ b/cmake_modules/dependencies/el5.cmake
@@ -20,5 +20,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, curl")
 ELSE ()
-    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1.6.0-openjdk")
+    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, java-1.6.0-openjdk")
 ENDIF ()

--- a/cmake_modules/dependencies/el6.cmake
+++ b/cmake_modules/dependencies/el6.cmake
@@ -20,5 +20,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, curl")
 ELSE ()
-    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1.6.0-openjdk")
+    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, java-1.6.0-openjdk")
 ENDIF ()

--- a/cmake_modules/dependencies/lenny.cmake
+++ b/cmake_modules/dependencies/lenny.cmake
@@ -20,5 +20,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3 ")
 ELSE ()
-    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, openjdk-6-jre")
 ENDIF ()

--- a/cmake_modules/dependencies/lucid.cmake
+++ b/cmake_modules/dependencies/lucid.cmake
@@ -19,5 +19,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3, libcurl3-nss")
 ELSE ()
-    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, openjdk-6-jre")
 ENDIF ()

--- a/cmake_modules/dependencies/natty.cmake
+++ b/cmake_modules/dependencies/natty.cmake
@@ -19,5 +19,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3, libcurl3-nss")
 ELSE ()
-    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, openjdk-6-jre")
 ENDIF ()

--- a/cmake_modules/dependencies/oneiric.cmake
+++ b/cmake_modules/dependencies/oneiric.cmake
@@ -19,6 +19,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3, libcurl3-nss")
 ELSE ()
-    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
-    set ( CPACK_RPM_PACKAGE_CONFLICTS "hpccsystems-libhdfsconnector")
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, openjdk-6-jre")
 ENDIF ()

--- a/cmake_modules/dependencies/precise.cmake
+++ b/cmake_modules/dependencies/precise.cmake
@@ -19,6 +19,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3, libcurl3-nss")
 ELSE ()
-    #set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
     set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, openjdk-6-jre")
 ENDIF ()

--- a/cmake_modules/dependencies/quantal.cmake
+++ b/cmake_modules/dependencies/quantal.cmake
@@ -19,5 +19,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, libcurl3, libcurl3-nss")
 ELSE ()
-    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, openjdk-6-jre")
 ENDIF ()

--- a/cmake_modules/dependencies/squeeze.cmake
+++ b/cmake_modules/dependencies/squeeze.cmake
@@ -19,5 +19,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, curl")
 ELSE ()
-    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, hadoop, openjdk-6-jre")
+    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hpccsystems-platform, openjdk-6-jre")
 ENDIF ()

--- a/cmake_modules/dependencies/suse11.3.cmake
+++ b/cmake_modules/dependencies/suse11.3.cmake
@@ -18,5 +18,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_RPM_PACKAGE_REQUIRES  "hpccsystems-platform, libcurl4 ")
 ELSE ()
-    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1_6_0-openjdk")
+    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, java-1_6_0-openjdk")
 ENDIF ()

--- a/cmake_modules/dependencies/suse11.4.cmake
+++ b/cmake_modules/dependencies/suse11.4.cmake
@@ -18,5 +18,5 @@
 IF ( BUILD_WEBHDFS_VER )
 	set ( CPACK_RPM_PACKAGE_REQUIRES  "hpccsystems-platform, libcurl4 ")
 ELSE ()
-    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, hadoop, java-1_6_0-openjdk")
+    set ( CPACK_RPM_PACKAGE_REQUIRES "hpccsystems-platform, java-1_6_0-openjdk")
 ENDIF ()


### PR DESCRIPTION
hadoop 2.2+ does not have a standard install package, remove hadoop from dep list. 
User is now responsible for providing libhdfs.

Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
